### PR TITLE
fix: adds region-specific s3 domain to the NO_PROXY list

### DIFF
--- a/cloudformation/eks-workers.yaml
+++ b/cloudformation/eks-workers.yaml
@@ -356,7 +356,7 @@ Resources:
           Environment="HTTPS_PROXY=${HttpsProxy}"
           Environment="http_proxy=${HttpsProxy}"
           Environment="HTTP_PROXY=${HttpsProxy}"
-          Environment="NO_PROXY=169.254.169.254,${VpcCidr},$CLUSTER_API_HOSTNAME,s3.amazonaws.com,ec2.${AWS::Region}.amazonaws.com,ecr.${AWS::Region}.amazonaws.com,dkr.ecr.${AWS::Region}.amazonaws.com"
+          Environment="NO_PROXY=169.254.169.254,${VpcCidr},$CLUSTER_API_HOSTNAME,s3.amazonaws.com,s3.${AWS::Region}.amazonaws.com,ec2.${AWS::Region}.amazonaws.com,ecr.${AWS::Region}.amazonaws.com,dkr.ecr.${AWS::Region}.amazonaws.com"
           EOF
 
           mkdir -p /usr/lib/systemd/system/docker.service.d


### PR DESCRIPTION
First of all, thanks for this great example!

I noticed that the system pods were not starting, and was able to track this down to the region-specific S3 domain being used to fetch the layers.

After updating the proxy configuration to include this domain in the NO_PROXY list, everything started as expected.